### PR TITLE
GIF Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ MongoDB Installation Guide: https://coding-boot-camp.github.io/full-stack/mongod
 
 ## Gameplay
 
-![Game](https://i.imgur.com/P5vfPi2.gif)
+[Click Here](https://i.imgur.com/P5vfPi2.gif)
 
 ## Credits  
 


### PR DESCRIPTION
This PR changes the GIF link to just link to an external website since the file is too big to be embedded.